### PR TITLE
Read options from config to support querying in different languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-04-09
+- Updated to Bridgetown 2.1 and Prismic.io 1.8
+
 ## [1.0.1] - 2023-06-09
 
 - Use updated method signature for origin initializer

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The [Bridgetown](https://edge.bridgetownrb.com) Prismic plugin allows you to pul
 
 In addition, this plugin allows you to set up draft previews so you can see how your content will look before it's published and deployed as a static site. This will require you to host a preview site on a platform which supports Ruby Rack-based applications. We recommend [Render](https://render.com), but you can use Heroku or most other platforms which support Ruby (Rails, etc.).
 
-This plugin requires Ruby 3 and the latest alpha version of [Bridgetown 1.0](https://edge.bridgetownrb.com).
+This plugin requires Ruby 3+ and [Bridgetown 2.1](https://www.bridgetownrb.com) or later.
 
 ## Installation
 
@@ -36,25 +36,39 @@ to the top of the file, and then adding:
 include BridgetownPrismic::Roda::Previews
 ```
 
-right underneath `class RodaApp < Bridgetown::Rack::Roda`.
-
-Also ensure you have the Bridgetown SSR plugin installed (aka `plugin :bridgetown_ssr` is somewhere above your `route do |r|` block).
+right underneath `class RodaApp < Roda`.
 
 Your file should end up looking something like this:
 
 ```ruby
 require "bridgetown-prismic/roda/previews"
 
-class RodaApp < Bridgetown::Rack::Roda
+class RodaApp < Roda
   include BridgetownPrismic::Roda::Previews
 
-  plugin :bridgetown_ssr
+  plugin :bridgetown_server
 
   route do |r|
     r.bridgetown
   end
 end
 ```
+
+You'll also need the Bridgetown SSR plugin enabled, which is what provides the
+`bridgetown_site` helper the preview routes rely on. As of Bridgetown 2.x this is
+no longer loaded directly in `roda_app.rb` — instead, enable it via an initializer.
+Open `config/initializers.rb` and make sure `init :ssr` is present (uncomment it,
+as it ships commented out by default) inside the `Bridgetown.configure` block:
+
+```ruby
+Bridgetown.configure do |config|
+  # ...
+  init :ssr
+end
+```
+
+Without `init :ssr`, the preview routes will raise
+`undefined local variable or method 'bridgetown_site'`.
 
 Next, create a `server/routes/preview.rb` route file:
 

--- a/bridgetown-prismic.gemspec
+++ b/bridgetown-prismic.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "bridgetown", ">= 1.2.0.beta2", "< 2.0"
   spec.add_dependency "prismic.io", ">= 1.8"
-  spec.add_dependency "async", ">= 2.0"
+  spec.add_dependency "async", ">= 1.30", "< 2.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", ">= 13.0"

--- a/bridgetown-prismic.gemspec
+++ b/bridgetown-prismic.gemspec
@@ -15,13 +15,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r!^test/!)
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 4.0"
 
-  spec.add_dependency "bridgetown", ">= 1.2.0", "< 2.0"
-  spec.add_dependency "prismic.io", ">= 1.8"
-  spec.add_dependency "async", ">= 1.30", "< 2.0"
+  spec.add_dependency "bridgetown", "~> 2.1"
+  spec.add_dependency "prismic.io", "~> 1.8"
+  spec.add_dependency "async", "~> 2.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", ">= 13.0"
-  spec.add_development_dependency "rubocop-bridgetown", "~> 0.3"
+  spec.add_development_dependency "rubocop-bridgetown", "~> 0.7"
 end

--- a/lib/bridgetown-prismic.rb
+++ b/lib/bridgetown-prismic.rb
@@ -33,7 +33,7 @@ Bridgetown::Model::Base.class_eval do # rubocop:disable Metrics/BlockLength
     site = Bridgetown::Current.site
     @prismic_data = Bridgetown::Utils::PrismicData.new(scope: self)
 
-    unless doc
+    unless doc && doc.instance_of?(Prismic::Document)
       prismic_id = origin.id.split("/").last
       # NOTE: if site.config.prismic_preview_token isn't set, it will default to
       # master (published) ref

--- a/lib/bridgetown-prismic/api.rb
+++ b/lib/bridgetown-prismic/api.rb
@@ -35,6 +35,8 @@ module BridgetownPrismic
       page = 1
       finalpage = false
       options["pageSize"] ||= 100 # pull in as much data as possible for a single request
+      query_options = Bridgetown::Current.site.config.prismic_query_options
+      options.merge!(query_options) if query_options
 
       until finalpage
         options["page"] = page

--- a/lib/bridgetown-prismic/origin.rb
+++ b/lib/bridgetown-prismic/origin.rb
@@ -12,8 +12,8 @@ module BridgetownPrismic
     def self.import_document(document) = new("prismic://#{document.type}/#{document.id}",
                                              document).read
 
-    def initialize(id, prismic_document = nil, site: Bridgetown::Current.site)
-      super(id, site: site)
+    def initialize(id, prismic_document = nil, site: Bridgetown::Current.site, bare_text: false)
+      super(id, site: site, bare_text: bare_text)
       @relative_path = Pathname.new("#{id.delete_prefix("prismic://")}.html")
       @prismic_document = prismic_document # could be nil, so model should load preview instance
     end

--- a/lib/bridgetown-prismic/version.rb
+++ b/lib/bridgetown-prismic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BridgetownPrismic
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/lib/bridgetown/utils/prismic_data.rb
+++ b/lib/bridgetown/utils/prismic_data.rb
@@ -2,7 +2,7 @@
 
 module Bridgetown
   module Utils
-    class PrismicData < RubyFrontMatter
+    class PrismicData < Bridgetown::FrontMatter::RubyFrontMatter
       def with_links = Bridgetown::Current.site.config.prismic_link_resolver
 
       def provide_data(&block)

--- a/test/fixtures/src/_layouts/default.html
+++ b/test/fixtures/src/_layouts/default.html
@@ -2,10 +2,10 @@
 ---
 <html>
   <head>
-    <title>{{ site.metadata.title }}</title>
+    <title><%= site.metadata.title %></title>
   </head>
   <body>
     THIS IS MY LAYOUT
-    {{ content }}
+    <%= yield %>
   </body>
 </html>

--- a/test/test_bridgetown_prismic.rb
+++ b/test/test_bridgetown_prismic.rb
@@ -8,7 +8,8 @@ class TestBridgetownPrismic < Bridgetown::TestCase
       "root_dir"    => root_dir,
       "source"      => source_dir,
       "destination" => dest_dir,
-      "quiet"       => true
+      "quiet"       => true,
+      "config"      => root_dir("bridgetown.config.yml")
     )
     @config.run_initializers! context: :static
     @site = Bridgetown::Site.new(@config)


### PR DESCRIPTION
Couldn't find the option to load resources from Prismic in different locales.